### PR TITLE
Fixed duration setting on iOS

### DIFF
--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -25,7 +25,7 @@
         NSMutableDictionary * updatedNowPlayingInfo = [NSMutableDictionary dictionaryWithDictionary:nowPlayingInfo];
         
         MPMediaItemArtwork * mediaItemArtwork = [self createCoverArtwork:[musicControlsInfo cover]];
-        NSNumber * duration = [NSNumber numberWithInt:[musicControlsInfo elapsed]];
+        NSNumber * duration = [NSNumber numberWithInt:[musicControlsInfo duration]];
         NSNumber * elapsed = [NSNumber numberWithInt:[musicControlsInfo elapsed]];
         NSNumber * playbackRate = [NSNumber numberWithBool:[musicControlsInfo isPlaying]];
         


### PR DESCRIPTION
Looks like copy-pasting error. Value by elapsed key used twice: as elapsed and as duration.