### PR TITLE
Add settings for ios prev/next track and skip forward/backward settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ MusicControls.create({
 
 	// iOS only, optional
 	album       : 'Absolution',     // optional, default: ''
-  	duration : 60, // optional, default: 0
-  	elapsed : 10, // optional, default: 0
+	duration : 60, // optional, default: 0
+	elapsed : 10, // optional, default: 0
+  	hasSkipForward : true, //optional, default: false. true value overrides hasNext.
+  	hasSkipBackward : true, //optional, default: false. true value overrides hasPrev.
+  	skipForwardInterval : 15, //optional. default: 0.
+	skipBackwardInterval : 15, //optional. default: 0. 
 
 	// Android only, optional
 	// text displayed in the status bar when the notification (and the ticker) are updated
@@ -75,7 +79,7 @@ function events(action) {
 			const seekToInSeconds = JSON.parse(action).position;
 			MusicControls.updateElapsed({
 				elapsed: seekToInSeconds,
-				isPlaying: true 
+				isPlaying: true
 			});
 			// Do something
 			break;
@@ -128,6 +132,11 @@ MusicControls.updateElapsed({
 'music-controls-media-button-meta-left', 'music-controls-media-button-meta-right', 'music-controls-media-button-music',
 'music-controls-media-button-volume-up', 'music-controls-media-button-volume-down', 'music-controls-media-button-volume-mute',
 'music-controls-media-button-headset-hook'
+
+- iOS Only:
+```javascript
+'music-controls-skip-forward', 'music-controls-skip-backward'
+```
 
 // Default:
 'music-controls-media-button'

--- a/src/ios/MusicControls.h
+++ b/src/ios/MusicControls.h
@@ -22,6 +22,10 @@
 - (void) updateElapsed: (CDVInvokedUrlCommand *) command;
 - (void) destroy: (CDVInvokedUrlCommand *) command;
 - (void) watch: (CDVInvokedUrlCommand *) command;
+- (void) nextTrackEvent:(MPRemoteCommandEvent *) event;
+- (void) prevTrackEvent:(MPRemoteCommandEvent *) event;
+- (void) skipForwardEvent: (MPSkipIntervalCommandEvent *) event;
+- (void) skipBackwardEvent: (MPSkipIntervalCommandEvent *) event;
 - (MPMediaItemArtwork *) createCoverArtwork: (NSString *) coverUri;
 - (bool) isCoverImageValid: (UIImage *) image;
 - (void) handleMusicControlsNotification:(NSNotification *) notification;

--- a/src/ios/MusicControlsInfo.h
+++ b/src/ios/MusicControlsInfo.h
@@ -1,6 +1,6 @@
 //
 //  MusicControlsInfo.h
-//  
+//
 //
 //  Created by Juan Gonzalez on 12/17/16.
 //
@@ -23,6 +23,10 @@
 @property bool isPlaying;
 @property bool hasPrev;
 @property bool hasNext;
+@property bool hasSkipForward;
+@property bool hasSkipBackward;
+@property int skipForwardInterval;
+@property int skipBackwardInterval;
 @property bool dismissable;
 
 - (id) initWithDictionary: (NSDictionary *) dictionary;

--- a/src/ios/MusicControlsInfo.m
+++ b/src/ios/MusicControlsInfo.m
@@ -1,6 +1,6 @@
- //
+//
 //  MusicControlsInfo.m
-//  
+//
 //
 //  Created by Juan Gonzalez on 12/17/16.
 //
@@ -11,22 +11,26 @@
 @implementation MusicControlsInfo : NSObject
 
 - (id) initWithDictionary: (NSDictionary *) dictionary {
-    
-    if (self = [super init]) {
-        [self setArtist: [dictionary objectForKey:@"artist"]];
-        [self setTrack: [dictionary objectForKey:@"track"]];
-        [self setAlbum: [dictionary objectForKey:@"album"]];
-        [self setTicker: [dictionary objectForKey:@"ticker"]];
-        [self setCover: [dictionary objectForKey:@"cover"]];
-        [self setDuration: [[dictionary objectForKey:@"duration"] integerValue]];
-        [self setElapsed: [[dictionary objectForKey:@"elapsed"] integerValue]];
-        [self setIsPlaying: [[dictionary objectForKey:@"isPlaying"] boolValue]];
-        [self setHasPrev: [[dictionary objectForKey:@"hasPrev"] boolValue]];
-        [self setHasNext: [[dictionary objectForKey:@"hasNext"] boolValue]];
-        [self setDismissable: [[dictionary objectForKey:@"dismissable"] boolValue]];
-    }
-    
-    return self;
+
+   if (self = [super init]) {
+       [self setArtist: [dictionary objectForKey:@"artist"]];
+       [self setTrack: [dictionary objectForKey:@"track"]];
+       [self setAlbum: [dictionary objectForKey:@"album"]];
+       [self setTicker: [dictionary objectForKey:@"ticker"]];
+       [self setCover: [dictionary objectForKey:@"cover"]];
+       [self setDuration: [[dictionary objectForKey:@"duration"] integerValue]];
+       [self setElapsed: [[dictionary objectForKey:@"elapsed"] integerValue]];
+       [self setIsPlaying: [[dictionary objectForKey:@"isPlaying"] boolValue]];
+       [self setHasPrev: [[dictionary objectForKey:@"hasPrev"] boolValue]];
+       [self setHasNext: [[dictionary objectForKey:@"hasNext"] boolValue]];
+       [self setHasSkipForward: [[dictionary objectForKey:@"hasSkipForward"] boolValue]];
+       [self setHasSkipBackward: [[dictionary objectForKey:@"hasSkipBackward"] boolValue]];
+       [self setSkipForwardInterval: [[dictionary objectForKey:@"skipForwardInterval"] integerValue]];
+       [self setSkipBackwardInterval: [[dictionary objectForKey:@"skipBackwardInterval"] integerValue]];
+       [self setDismissable: [[dictionary objectForKey:@"dismissable"] boolValue]];
+   }
+
+   return self;
 }
 
 @end

--- a/www/MusicControls.js
+++ b/www/MusicControls.js
@@ -12,6 +12,10 @@ var musicControls = {
     data.isPlaying = !isUndefined(data.isPlaying) ? data.isPlaying : true;
     data.hasPrev = !isUndefined(data.hasPrev) ? data.hasPrev : true;
     data.hasNext = !isUndefined(data.hasNext) ? data.hasNext : true;
+    data.hasSkipForward = !isUndefined(data.hasSkipForward) ? data.hasSkipForward : false;
+    data.hasSkipBackward = !isUndefined(data.hasSkipBackward) ? data.hasSkipBackward : false;
+    data.skipForwardInterval = !isUndefined(data.skipForwardInterval) ? data.skipForwardInterval : 0;
+    data.skipBackwardInterval = !isUndefined(data.skipBackwardInterval) ? data.skipBackwardInterval : 0;
     data.hasClose = !isUndefined(data.hasClose) ? data.hasClose : false;
     data.dismissable = !isUndefined(data.dismissable) ? data.dismissable : false;
 


### PR DESCRIPTION
This adds proper support in iOS to display next and previous track buttons, as well as the timecode skip forward and backward buttons. Music Controls should be version bumped to 2.1.0 if accepted.