### PR TITLE
Added Android custom icon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ MusicControls.create({
 
 	// Android only, optional
 	// text displayed in the status bar when the notification (and the ticker) are updated
-	ticker	  : 'Now playing "Time is Running Out"'
+	ticker	  : 'Now playing "Time is Running Out"',
+	//All icons default to their built-in android equivalents
+	//The supplied drawable name, e.g. 'media_play', is the name of a drawable found under android/res/drawable* folders
+	playIcon: 'media_play',
+	pauseIcon: 'media_pause',
+	prevIcon: 'media_prev',
+	nextIcon: 'media_next',
+	closeIcon: 'media_close',
+	notificationIcon: 'notification'
 }, onSuccess, onError);
 ```
 

--- a/src/android/MusicControlsInfos.java
+++ b/src/android/MusicControlsInfos.java
@@ -14,6 +14,12 @@ public class MusicControlsInfos{
 	public boolean hasNext;
 	public boolean hasClose;
 	public boolean dismissable;
+	public String playIcon;
+	public String pauseIcon;
+	public String prevIcon;
+	public String nextIcon;
+	public String closeIcon;
+	public String notificationIcon;
 
 	public MusicControlsInfos(JSONArray args) throws JSONException {
 		final JSONObject params = args.getJSONObject(0);
@@ -27,6 +33,12 @@ public class MusicControlsInfos{
 		this.hasNext = params.getBoolean("hasNext");
 		this.hasClose = params.getBoolean("hasClose");
 		this.dismissable = params.getBoolean("dismissable");
+		this.playIcon = params.getString("playIcon");
+		this.pauseIcon = params.getString("pauseIcon");
+		this.prevIcon = params.getString("prevIcon");
+		this.nextIcon = params.getString("nextIcon");
+		this.closeIcon = params.getString("closeIcon");
+		this.notificationIcon = params.getString("notificationIcon");
 	}
 
 }

--- a/src/android/MusicControlsNotification.java
+++ b/src/android/MusicControlsNotification.java
@@ -156,10 +156,21 @@ public class MusicControlsNotification {
 		}
 
 		//Set SmallIcon
-		if (infos.isPlaying){
-			builder.setSmallIcon(R.drawable.ic_media_play);
-		} else {
-			builder.setSmallIcon(R.drawable.ic_media_pause);
+		boolean usePlayingIcon = infos.notificationIcon.isEmpty();
+		if(!usePlayingIcon){
+			int resId = this.getResourceId(infos.notificationIcon, 0);
+			usePlayingIcon = resId == 0;
+			if(!usePlayingIcon) {
+				builder.setSmallIcon(resId);
+			}
+		}
+
+		if(usePlayingIcon){
+			if (infos.isPlaying){
+				builder.setSmallIcon(this.getResourceId(infos.playIcon, android.R.drawable.ic_media_play));
+			} else {
+				builder.setSmallIcon(this.getResourceId(infos.pauseIcon, android.R.drawable.ic_media_pause));
+			}
 		}
 
 		//Set LargeIcon
@@ -181,34 +192,34 @@ public class MusicControlsNotification {
 			nbControls++;
 			Intent previousIntent = new Intent("music-controls-previous");
 			PendingIntent previousPendingIntent = PendingIntent.getBroadcast(context, 1, previousIntent, 0);
-			builder.addAction(android.R.drawable.ic_media_previous, "", previousPendingIntent);
+			builder.addAction(this.getResourceId(infos.prevIcon, android.R.drawable.ic_media_previous), "", previousPendingIntent);
 		}
 		if (infos.isPlaying){
 			/* Pause  */
 			nbControls++;
 			Intent pauseIntent = new Intent("music-controls-pause");
 			PendingIntent pausePendingIntent = PendingIntent.getBroadcast(context, 1, pauseIntent, 0);
-			builder.addAction(android.R.drawable.ic_media_pause, "", pausePendingIntent);
+			builder.addAction(this.getResourceId(infos.pauseIcon, android.R.drawable.ic_media_pause), "", pausePendingIntent);
 		} else {
 			/* Play  */
 			nbControls++;
 			Intent playIntent = new Intent("music-controls-play");
 			PendingIntent playPendingIntent = PendingIntent.getBroadcast(context, 1, playIntent, 0);
-			builder.addAction(android.R.drawable.ic_media_play, "", playPendingIntent);
+			builder.addAction(this.getResourceId(infos.playIcon, android.R.drawable.ic_media_play), "", playPendingIntent);
 		}
 		/* Next */
 		if (infos.hasNext){
 			nbControls++;
 			Intent nextIntent = new Intent("music-controls-next");
 			PendingIntent nextPendingIntent = PendingIntent.getBroadcast(context, 1, nextIntent, 0);
-			builder.addAction(android.R.drawable.ic_media_next, "", nextPendingIntent);
+			builder.addAction(this.getResourceId(infos.nextIcon, android.R.drawable.ic_media_next), "", nextPendingIntent);
 		}
 		/* Close */
 		if (infos.hasClose){
 			nbControls++;
 			Intent destroyIntent = new Intent("music-controls-destroy");
 			PendingIntent destroyPendingIntent = PendingIntent.getBroadcast(context, 1, destroyIntent, 0);
-			builder.addAction(android.R.drawable.ic_menu_close_clear_cancel, "", destroyPendingIntent);
+			builder.addAction(this.getResourceId(infos.closeIcon, android.R.drawable.ic_menu_close_clear_cancel), "", destroyPendingIntent);
 		}
 
 		//If 5.0 >= use MediaStyle
@@ -222,6 +233,19 @@ public class MusicControlsNotification {
 		this.notificationBuilder = builder;
 	}
 
+	private int getResourceId(String name, int fallback){
+		try{
+			if(name.isEmpty()){
+				return fallback;
+			}
+
+			int resId = this.cordovaActivity.getResources().getIdentifier(name, "drawable", this.cordovaActivity.getPackageName());
+			return resId == 0 ? fallback : resId;
+		}
+		catch(Exception ex){
+			return fallback;
+		}
+	}
 
 	public void destroy(){
 		this.notificationManager.cancel(this.notificationID);

--- a/www/MusicControls.js
+++ b/www/MusicControls.js
@@ -18,6 +18,12 @@ var musicControls = {
     data.skipBackwardInterval = !isUndefined(data.skipBackwardInterval) ? data.skipBackwardInterval : 0;
     data.hasClose = !isUndefined(data.hasClose) ? data.hasClose : false;
     data.dismissable = !isUndefined(data.dismissable) ? data.dismissable : false;
+    data.playIcon = !isUndefined(data.playIcon) ? data.playIcon : '';
+    data.pauseIcon = !isUndefined(data.pauseIcon) ? data.pauseIcon : '';
+    data.prevIcon = !isUndefined(data.prevIcon) ? data.prevIcon : '';
+    data.nextIcon = !isUndefined(data.nextIcon) ? data.nextIcon : '';
+    data.closeIcon = !isUndefined(data.closeIcon) ? data.closeIcon : '';
+    data.notificationIcon = !isUndefined(data.notificationIcon) ? data.notificationIcon : '';
 
     cordova.exec(successCallback, errorCallback, 'MusicControls', 'create', [data]);
   },


### PR DESCRIPTION
You can now supply the name of custom icons for play, pause, prev, next, close, and the general notification icon (in place of the play/pause icon).

E.g. in options:
{
  ...,
  playIcon: 'media_play',
  ...
}