### PR TITLE
Resolves #90, #89, #75, #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Music controls for Cordova applications. Display a 'media' notification with pla
 ## Supported platforms
 - Android (4.1+)
 - Windows (10+, by [filfat](https://github.com/filfat))
-- iOS (by [0505gonzalez](https://github.com/0505gonzalez))
+- iOS 8+ (by [0505gonzalez](https://github.com/0505gonzalez))
 
 ## Installation
 `cordova plugin add https://github.com/homerours/cordova-music-controls-plugin`
@@ -36,7 +36,8 @@ MusicControls.create({
   	hasSkipForward : true, //optional, default: false. true value overrides hasNext.
   	hasSkipBackward : true, //optional, default: false. true value overrides hasPrev.
   	skipForwardInterval : 15, //optional. default: 0.
-	skipBackwardInterval : 15, //optional. default: 0. 
+	skipBackwardInterval : 15, //optional. default: 0.
+	hasScrubbing : false, //optional. default to false. Enable scrubbing from control center progress bar 
 
 	// Android only, optional
 	// text displayed in the status bar when the notification (and the ticker) are updated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-music-controls",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "cordova-plugin-music-controls",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
 	id="cordova-plugin-music-controls"
-	version="2.1.1">
+	version="2.1.2">
 	<name>MusicControls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
 	<repo>https://github.com/homerours/cordova-music-controls-plugin</repo>

--- a/src/ios/MusicControls.h
+++ b/src/ios/MusicControls.h
@@ -22,8 +22,7 @@
 - (void) updateElapsed: (CDVInvokedUrlCommand *) command;
 - (void) destroy: (CDVInvokedUrlCommand *) command;
 - (void) watch: (CDVInvokedUrlCommand *) command;
-- (void) nextTrackEvent:(MPRemoteCommandEvent *) event;
-- (void) prevTrackEvent:(MPRemoteCommandEvent *) event;
+- (void) remoteEvent:(MPRemoteCommandEvent *) event;
 - (void) skipForwardEvent: (MPSkipIntervalCommandEvent *) event;
 - (void) skipBackwardEvent: (MPSkipIntervalCommandEvent *) event;
 - (MPMediaItemArtwork *) createCoverArtwork: (NSString *) coverUri;

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -1,14 +1,16 @@
 //
 //  MusicControls.m
-//
+//  
 //
 //  Created by Juan Gonzalez on 12/16/16.
+//  Updated by Gaven Henry on 11/7/17 for iOS 11 compatibility & new features
 //
 //
 
 #import "MusicControls.h"
 #import "MusicControlsInfo.h"
 
+//save the passed in info globally so we can configure the enabled/disabled commands and skip intervals
 MusicControlsInfo * musicControlsSettings;
 
 @implementation MusicControls
@@ -17,32 +19,32 @@ MusicControlsInfo * musicControlsSettings;
     NSDictionary * musicControlsInfoDict = [command.arguments objectAtIndex:0];
     MusicControlsInfo * musicControlsInfo = [[MusicControlsInfo alloc] initWithDictionary:musicControlsInfoDict];
     musicControlsSettings = musicControlsInfo;
-
+    
     if (!NSClassFromString(@"MPNowPlayingInfoCenter")) {
         return;
     }
-
+    
     [self.commandDelegate runInBackground:^{
         MPNowPlayingInfoCenter * nowPlayingInfoCenter =  [MPNowPlayingInfoCenter defaultCenter];
         NSDictionary * nowPlayingInfo = nowPlayingInfoCenter.nowPlayingInfo;
         NSMutableDictionary * updatedNowPlayingInfo = [NSMutableDictionary dictionaryWithDictionary:nowPlayingInfo];
-
+        
         MPMediaItemArtwork * mediaItemArtwork = [self createCoverArtwork:[musicControlsInfo cover]];
         NSNumber * duration = [NSNumber numberWithInt:[musicControlsInfo duration]];
         NSNumber * elapsed = [NSNumber numberWithInt:[musicControlsInfo elapsed]];
         NSNumber * playbackRate = [NSNumber numberWithBool:[musicControlsInfo isPlaying]];
-
+        
         if (mediaItemArtwork != nil) {
             [updatedNowPlayingInfo setObject:mediaItemArtwork forKey:MPMediaItemPropertyArtwork];
         }
-
+        
         [updatedNowPlayingInfo setObject:[musicControlsInfo artist] forKey:MPMediaItemPropertyArtist];
         [updatedNowPlayingInfo setObject:[musicControlsInfo track] forKey:MPMediaItemPropertyTitle];
         [updatedNowPlayingInfo setObject:[musicControlsInfo album] forKey:MPMediaItemPropertyAlbumTitle];
         [updatedNowPlayingInfo setObject:duration forKey:MPMediaItemPropertyPlaybackDuration];
         [updatedNowPlayingInfo setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
         [updatedNowPlayingInfo setObject:playbackRate forKey:MPNowPlayingInfoPropertyPlaybackRate];
-
+        
         nowPlayingInfoCenter.nowPlayingInfo = updatedNowPlayingInfo;
     }];
 }
@@ -50,35 +52,25 @@ MusicControlsInfo * musicControlsSettings;
 - (void) updateIsPlaying: (CDVInvokedUrlCommand *) command {
     NSDictionary * musicControlsInfoDict = [command.arguments objectAtIndex:0];
     MusicControlsInfo * musicControlsInfo = [[MusicControlsInfo alloc] initWithDictionary:musicControlsInfoDict];
+    NSNumber * elapsed = [NSNumber numberWithDouble:[musicControlsInfo elapsed]];
     NSNumber * playbackRate = [NSNumber numberWithBool:[musicControlsInfo isPlaying]];
-
+    
     if (!NSClassFromString(@"MPNowPlayingInfoCenter")) {
         return;
     }
 
     MPNowPlayingInfoCenter * nowPlayingCenter = [MPNowPlayingInfoCenter defaultCenter];
     NSMutableDictionary * updatedNowPlayingInfo = [NSMutableDictionary dictionaryWithDictionary:nowPlayingCenter.nowPlayingInfo];
-
+    
+    [updatedNowPlayingInfo setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
     [updatedNowPlayingInfo setObject:playbackRate forKey:MPNowPlayingInfoPropertyPlaybackRate];
     nowPlayingCenter.nowPlayingInfo = updatedNowPlayingInfo;
 }
 
+// this was performing the full function of updateIsPlaying and just adding elapsed time update as well
+// moved the elapsed update into updateIsPlaying and made this just pass through to reduce code duplication
 - (void) updateElapsed: (CDVInvokedUrlCommand *) command {
-    NSDictionary * musicControlsInfoDict = [command.arguments objectAtIndex:0];
-    MusicControlsInfo * musicControlsInfo = [[MusicControlsInfo alloc] initWithDictionary:musicControlsInfoDict];
-    NSNumber * elapsed = [NSNumber numberWithDouble:[musicControlsInfo elapsed]];
-    NSNumber * playbackRate = [NSNumber numberWithBool:[musicControlsInfo isPlaying]];
-
-    if (!NSClassFromString(@"MPNowPlayingInfoCenter")) {
-        return;
-    }
-
-    MPNowPlayingInfoCenter * nowPlayingCenter = [MPNowPlayingInfoCenter defaultCenter];
-    NSMutableDictionary * updatedNowPlayingInfo = [NSMutableDictionary dictionaryWithDictionary:nowPlayingCenter.nowPlayingInfo];
-
-    [updatedNowPlayingInfo setObject:elapsed forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
-    [updatedNowPlayingInfo setObject:playbackRate forKey:MPNowPlayingInfoPropertyPlaybackRate];
-    nowPlayingCenter.nowPlayingInfo = updatedNowPlayingInfo;
+    [self updateIsPlaying:(command)];
 }
 
 - (void) destroy: (CDVInvokedUrlCommand *) command {
@@ -92,20 +84,20 @@ MusicControlsInfo * musicControlsSettings;
 
 - (MPMediaItemArtwork *) createCoverArtwork: (NSString *) coverUri {
     UIImage * coverImage = nil;
-
+    
     if (coverUri == nil) {
         return nil;
     }
-
+    
     if ([coverUri hasPrefix:@"http://"] || [coverUri hasPrefix:@"https://"]) {
         NSURL * coverImageUrl = [NSURL URLWithString:coverUri];
         NSData * coverImageData = [NSData dataWithContentsOfURL: coverImageUrl];
-
+        
         coverImage = [UIImage imageWithData: coverImageData];
     }
     else if ([coverUri hasPrefix:@"file://"]) {
         NSString * fullCoverImagePath = [coverUri stringByReplacingOccurrencesOfString:@"file://" withString:@""];
-
+        
         if ([[NSFileManager defaultManager] fileExistsAtPath: fullCoverImagePath]) {
             coverImage = [[UIImage alloc] initWithContentsOfFile: fullCoverImagePath];
         }
@@ -113,7 +105,7 @@ MusicControlsInfo * musicControlsSettings;
     else if (![coverUri isEqual:@""]) {
         NSString * baseCoverImagePath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
         NSString * fullCoverImagePath = [NSString stringWithFormat:@"%@%@", baseCoverImagePath, coverUri];
-
+    
         if ([[NSFileManager defaultManager] fileExistsAtPath:fullCoverImagePath]) {
             coverImage = [UIImage imageNamed:fullCoverImagePath];
         }
@@ -121,7 +113,7 @@ MusicControlsInfo * musicControlsSettings;
     else {
         coverImage = [UIImage imageNamed:@"none"];
     }
-
+    
     return [self isCoverImageValid:coverImage] ? [[MPMediaItemArtwork alloc] initWithImage:coverImage] : nil;
 }
 
@@ -129,116 +121,7 @@ MusicControlsInfo * musicControlsSettings;
     return coverImage != nil && ([coverImage CIImage] != nil || [coverImage CGImage] != nil);
 }
 
-- (void) handleMusicControlsNotification: (NSNotification *) notification {
-    UIEvent * receivedEvent = notification.object;
-
-    if ([self latestEventCallbackId] == nil) {
-        return;
-    }
-
-    if (receivedEvent.type == UIEventTypeRemoteControl) {
-        NSString * action;
-
-        switch (receivedEvent.subtype) {
-            case UIEventSubtypeRemoteControlTogglePlayPause:
-                action = @"music-controls-toggle-play-pause";
-                break;
-
-            case UIEventSubtypeRemoteControlPlay:
-                action = @"music-controls-play";
-                break;
-
-            case UIEventSubtypeRemoteControlPause:
-                action = @"music-controls-pause";
-                break;
-
-            case UIEventSubtypeRemoteControlPreviousTrack:
-                action = @"music-controls-previous";
-                break;
-
-            case UIEventSubtypeRemoteControlNextTrack:
-                action = @"music-controls-next";
-                break;
-
-            case UIEventSubtypeRemoteControlStop:
-                action = @"music-controls-destroy";
-                break;
-
-            default:
-                break;
-        }
-
-        NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
-        CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
-    }
-}
-
-- (void) nextTrackEvent:(MPRemoteCommandEvent *)event {
-    NSString * action = @"music-controls-next";
-    NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
-    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
-}
-- (void) prevTrackEvent:(MPRemoteCommandEvent *)event {
-    NSString * action = @"music-controls-previous";
-    NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
-    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
-}
-
-- (void) skipForwardEvent:(MPSkipIntervalCommandEvent *)event {
-    NSString * action = @"music-controls-skip-forward";
-    NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
-    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
-}
-
-- (void) skipBackwardEvent:(MPSkipIntervalCommandEvent *)event {
-    NSString * action = @"music-controls-skip-backward";
-    NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
-    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
-}
-
-- (void) registerMusicControlsEventListener {
-    [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleMusicControlsNotification:) name:@"musicControlsEventNotification" object:nil];
-    
-    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_0) {
-      //only available in iOS 9.1 and up.
-        MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
-        [commandCenter.changePlaybackPositionCommand setEnabled:true];
-        [commandCenter.changePlaybackPositionCommand addTarget:self action:@selector(changedThumbSliderOnLockScreen:)];
-
-        if (musicControlsSettings.hasNext) {
-          MPRemoteCommand *nextTrackCommand = [commandCenter nextTrackCommand];
-          [nextTrackCommand setEnabled:YES];
-          [nextTrackCommand addTarget:self action:@selector(nextTrackEvent:)];
-        }
-
-        if (musicControlsSettings.hasPrev) {
-          MPRemoteCommand *prevTrackCommand = [commandCenter previousTrackCommand];
-          [prevTrackCommand setEnabled:YES];
-          [prevTrackCommand addTarget:self action:@selector(prevTrackEvent:)];
-        }
-
-        if (musicControlsSettings.hasSkipForward) {
-          MPSkipIntervalCommand *skipForwardIntervalCommand = [commandCenter skipForwardCommand];
-          skipForwardIntervalCommand.preferredIntervals = @[@(musicControlsSettings.skipForwardInterval)];
-          [skipForwardIntervalCommand setEnabled:YES];
-          [skipForwardIntervalCommand addTarget:self action:@selector(skipForwardEvent:)];
-        }
-
-        if (musicControlsSettings.hasSkipBackward) {
-          MPSkipIntervalCommand *skipBackwardIntervalCommand = [commandCenter skipBackwardCommand];
-          skipBackwardIntervalCommand.preferredIntervals = @[@(musicControlsSettings.skipBackwardInterval)];
-          [skipBackwardIntervalCommand setEnabled:YES];
-          [skipBackwardIntervalCommand addTarget:self action:@selector(skipBackwardEvent:)];
-        }
-    }
-}
-
+//Handle seeking with the progress slider on lockscreen or control center
 - (MPRemoteCommandHandlerStatus)changedThumbSliderOnLockScreen:(MPChangePlaybackPositionCommandEvent *)event {
     NSString * seekTo = [NSString stringWithFormat:@"{\"message\":\"music-controls-seek-to\",\"position\":\"%f\"}", event.positionTime];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:seekTo];
@@ -247,22 +130,138 @@ MusicControlsInfo * musicControlsSettings;
     return MPRemoteCommandHandlerStatusSuccess;
 }
 
+//Handle the skip forward event
+- (void) skipForwardEvent:(MPSkipIntervalCommandEvent *)event {
+    NSString * action = @"music-controls-skip-forward";
+    NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
+    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
+}
+
+//Handle the skip backward event
+- (void) skipBackwardEvent:(MPSkipIntervalCommandEvent *)event {
+    NSString * action = @"music-controls-skip-backward";
+    NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
+    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
+}
+
+//If MPRemoteCommandCenter is enabled for any function we must enable it for all and register a handler
+//So if we want to use the new scrubbing support in the lock screen we must implement dummy handlers
+//for those functions that we already deal with through notifications (play, pause, skip etc)
+//otherwise those remote control actions will be disabled
+- (void) remoteEvent:(MPRemoteCommandEvent *)event {
+    NSLog(@"%@", event);
+    return;
+}
+
+//Handle all other remote control events
+- (void) handleMusicControlsNotification: (NSNotification *) notification {
+    UIEvent * receivedEvent = notification.object;
+    
+    if ([self latestEventCallbackId] == nil) {
+        return;
+    }
+    
+    if (receivedEvent.type == UIEventTypeRemoteControl) {
+        NSString * action;
+        
+        switch (receivedEvent.subtype) {
+            case UIEventSubtypeRemoteControlTogglePlayPause:
+                action = @"music-controls-toggle-play-pause";
+                break;
+                
+            case UIEventSubtypeRemoteControlPlay:
+                action = @"music-controls-play";
+                break;
+                
+            case UIEventSubtypeRemoteControlPause:
+                action = @"music-controls-pause";
+                break;
+                
+            case UIEventSubtypeRemoteControlPreviousTrack:
+                action = @"music-controls-previous";
+                break;
+                
+            case UIEventSubtypeRemoteControlNextTrack:
+                action = @"music-controls-next";
+                break;
+                
+            case UIEventSubtypeRemoteControlStop:
+                action = @"music-controls-destroy";
+                break;
+                
+            default:
+                action = nil;
+                break;
+        }
+        
+        if(action == nil){
+            return;
+        }
+        
+        NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
+        CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
+    }
+}
+
+//There are only 3 button slots available so next/prev track and skip forward/back cannot both be enabled
+//skip forward/back will take precedence if both are enabled
+- (void) registerMusicControlsEventListener {
+    [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleMusicControlsNotification:) name:@"musicControlsEventNotification" object:nil];
+    
+    //register required event handlers for standard controls
+    MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+    [commandCenter.playCommand setEnabled:true];
+    [commandCenter.playCommand addTarget:self action:@selector(remoteEvent:)];
+    [commandCenter.pauseCommand setEnabled:true];
+    [commandCenter.pauseCommand addTarget:self action:@selector(remoteEvent:)];
+    if(musicControlsSettings.hasNext){
+        [commandCenter.nextTrackCommand setEnabled:true];
+        [commandCenter.nextTrackCommand addTarget:self action:@selector(remoteEvent:)];
+    }
+    if(musicControlsSettings.hasPrev){
+        [commandCenter.previousTrackCommand setEnabled:true];
+        [commandCenter.previousTrackCommand addTarget:self action:@selector(remoteEvent:)];
+    }
+
+    //Some functions are not available in earlier versions
+    if(floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_0){
+        if(musicControlsSettings.hasSkipForward){
+            commandCenter.skipForwardCommand.preferredIntervals = @[@(musicControlsSettings.skipForwardInterval)];
+            [commandCenter.skipForwardCommand setEnabled:true];
+            [commandCenter.skipForwardCommand addTarget: self action:@selector(skipForwardEvent:)];
+        }
+        if(musicControlsSettings.hasSkipBackward){
+            commandCenter.skipBackwardCommand.preferredIntervals = @[@(musicControlsSettings.skipForwardInterval)];
+            [commandCenter.skipBackwardCommand setEnabled:true];
+            [commandCenter.skipBackwardCommand addTarget: self action:@selector(skipBackwardEvent:)];
+        }
+        if(musicControlsSettings.hasScrubbing){
+            [commandCenter.changePlaybackPositionCommand setEnabled:true];
+            [commandCenter.changePlaybackPositionCommand addTarget:self action:@selector(changedThumbSliderOnLockScreen:)];
+        }
+    }
+}
+
 - (void) deregisterMusicControlsEventListener {
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"receivedEvent" object:nil];
-    [self setLatestEventCallbackId:nil];
-
+    
+    MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+    [commandCenter.nextTrackCommand removeTarget:self];
+    [commandCenter.previousTrackCommand removeTarget:self];
+    
     if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_0) {
-        MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
         [commandCenter.changePlaybackPositionCommand setEnabled:false];
         [commandCenter.changePlaybackPositionCommand removeTarget:self action:NULL];
-
         [commandCenter.skipForwardCommand removeTarget:self];
         [commandCenter.skipBackwardCommand removeTarget:self];
-
-        [commandCenter.nextTrackCommand removeTarget:self];
-        [commandCenter.previousTrackCommand removeTarget:self];
     }
+    
+    [self setLatestEventCallbackId:nil];
 }
 
 - (void) dealloc {

--- a/src/ios/MusicControlsInfo.h
+++ b/src/ios/MusicControlsInfo.h
@@ -19,7 +19,7 @@
 @property NSString * ticker;
 @property NSString * cover;
 @property NSUInteger duration;
-@property MSUInteger elapsed;
+@property NSUInteger elapsed;
 @property bool isPlaying;
 @property bool hasPrev;
 @property bool hasNext;

--- a/src/ios/MusicControlsInfo.h
+++ b/src/ios/MusicControlsInfo.h
@@ -18,15 +18,16 @@
 @property NSString * album;
 @property NSString * ticker;
 @property NSString * cover;
-@property int duration;
-@property int elapsed;
+@property NSUInteger duration;
+@property MSUInteger elapsed;
 @property bool isPlaying;
 @property bool hasPrev;
 @property bool hasNext;
 @property bool hasSkipForward;
 @property bool hasSkipBackward;
-@property int skipForwardInterval;
-@property int skipBackwardInterval;
+@property bool hasScrubbing;
+@property NSUInteger skipForwardInterval;
+@property NSUInteger skipBackwardInterval;
 @property bool dismissable;
 
 - (id) initWithDictionary: (NSDictionary *) dictionary;

--- a/src/ios/MusicControlsInfo.m
+++ b/src/ios/MusicControlsInfo.m
@@ -12,23 +12,24 @@
 
 - (id) initWithDictionary: (NSDictionary *) dictionary {
 
-   if (self = [super init]) {
-       [self setArtist: [dictionary objectForKey:@"artist"]];
-       [self setTrack: [dictionary objectForKey:@"track"]];
-       [self setAlbum: [dictionary objectForKey:@"album"]];
-       [self setTicker: [dictionary objectForKey:@"ticker"]];
-       [self setCover: [dictionary objectForKey:@"cover"]];
-       [self setDuration: [[dictionary objectForKey:@"duration"] integerValue]];
-       [self setElapsed: [[dictionary objectForKey:@"elapsed"] integerValue]];
-       [self setIsPlaying: [[dictionary objectForKey:@"isPlaying"] boolValue]];
-       [self setHasPrev: [[dictionary objectForKey:@"hasPrev"] boolValue]];
-       [self setHasNext: [[dictionary objectForKey:@"hasNext"] boolValue]];
-       [self setHasSkipForward: [[dictionary objectForKey:@"hasSkipForward"] boolValue]];
-       [self setHasSkipBackward: [[dictionary objectForKey:@"hasSkipBackward"] boolValue]];
-       [self setSkipForwardInterval: [[dictionary objectForKey:@"skipForwardInterval"] integerValue]];
-       [self setSkipBackwardInterval: [[dictionary objectForKey:@"skipBackwardInterval"] integerValue]];
-       [self setDismissable: [[dictionary objectForKey:@"dismissable"] boolValue]];
-   }
+    if (self = [super init]) {
+        [self setArtist: [dictionary objectForKey:@"artist"]];
+        [self setTrack: [dictionary objectForKey:@"track"]];
+        [self setAlbum: [dictionary objectForKey:@"album"]];
+        [self setTicker: [dictionary objectForKey:@"ticker"]];
+        [self setCover: [dictionary objectForKey:@"cover"]];
+        [self setDuration: [[dictionary objectForKey:@"duration"] integerValue]];
+        [self setElapsed: [[dictionary objectForKey:@"elapsed"] integerValue]];
+        [self setIsPlaying: [[dictionary objectForKey:@"isPlaying"] boolValue]];
+        [self setHasPrev: [[dictionary objectForKey:@"hasPrev"] boolValue]];
+        [self setHasNext: [[dictionary objectForKey:@"hasNext"] boolValue]];
+        [self setHasSkipForward: [[dictionary objectForKey:@"hasSkipForward"] boolValue]];
+        [self setHasSkipBackward: [[dictionary objectForKey:@"hasSkipBackward"] boolValue]];
+        [self setHasScrubbing: [[dictionary objectForKey:@"hasScrubbing"] boolValue]];
+        [self setSkipForwardInterval: [[dictionary objectForKey:@"skipForwardInterval"] integerValue]];
+        [self setSkipBackwardInterval: [[dictionary objectForKey:@"skipBackwardInterval"] integerValue]];
+        [self setDismissable: [[dictionary objectForKey:@"dismissable"] boolValue]];
+    }
 
    return self;
 }

--- a/www/MusicControls.js
+++ b/www/MusicControls.js
@@ -14,6 +14,7 @@ var musicControls = {
     data.hasNext = !isUndefined(data.hasNext) ? data.hasNext : true;
     data.hasSkipForward = !isUndefined(data.hasSkipForward) ? data.hasSkipForward : false;
     data.hasSkipBackward = !isUndefined(data.hasSkipBackward) ? data.hasSkipBackward : false;
+    data.hasScrubbing = !isUndefined(data.hasScrubbing) ? data.hasScrubbing : false;
     data.skipForwardInterval = !isUndefined(data.skipForwardInterval) ? data.skipForwardInterval : 0;
     data.skipBackwardInterval = !isUndefined(data.skipBackwardInterval) ? data.skipBackwardInterval : 0;
     data.hasClose = !isUndefined(data.hasClose) ? data.hasClose : false;


### PR DESCRIPTION
This PR should resolve a lot of the issues currently being experienced with ios11 or even with ios10 with the 2.x+ versions of the plugin.

I ran into the same issues as reported when I updated to the v2.x+ versions and needed to find a reliable working solution.

This PR only changes iOS and adds 1 variable to the javascript interface for iOS only.

javascript changes:
hasScrubbing: true/false, default to false.  Enable scrubbing from the progress bar in lock screen or control center.

iOS native changes:
combine updateIsPlaying and updateElapsed to reduce repeated code.  updateElapsed now just forwards to updateIsPlaying and is maintained for compatibility for now.

register proper events for handling play/pause/nexttrack/prevtrack so that the control buttons are enabled correctly in both control center and lock screen.

remove unused functions for next/prev track.

basic functions still handled by the notification mechanism.  New functions for scrubbing and skip intervals are handled by specific handlers.

Moved basic next/prev track functions outside the ios version check as these work all the way back to ios7 and if not registered you cannot skip.

Moved new skip interval and scrubbing functions inside the ios version check.

Actually disable next/prev track when set to false.

Fixed bug that was causing next/prev to forward wrong events, breaking next/prev functionality.

Tested on iOS11 and iOS10 on iphone6 and all functions are working.

Note that there are only 3 button slots on the remote controls so you can have EITHER next/prev track OR skip forward/back.