### PR TITLE
Prevent controls from registering multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-music-controls",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Music controls for Cordova apps",
   "cordova": {
     "id": "cordova-plugin-music-controls",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
 	id="cordova-plugin-music-controls"
-	version="2.1.2">
+	version="2.1.3">
 	<name>MusicControls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
 	<repo>https://github.com/homerours/cordova-music-controls-plugin</repo>

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -47,6 +47,8 @@ MusicControlsInfo * musicControlsSettings;
         
         nowPlayingInfoCenter.nowPlayingInfo = updatedNowPlayingInfo;
     }];
+
+    [self registerMusicControlsEventListener];
 }
 
 - (void) updateIsPlaying: (CDVInvokedUrlCommand *) command {
@@ -79,7 +81,6 @@ MusicControlsInfo * musicControlsSettings;
 
 - (void) watch: (CDVInvokedUrlCommand *) command {
     [self setLatestEventCallbackId:command.callbackId];
-    [self registerMusicControlsEventListener];
 }
 
 - (MPMediaItemArtwork *) createCoverArtwork: (NSString *) coverUri {


### PR DESCRIPTION
Moving this prevents the controls from binding multiple times and firing in ever increasing amounts. As far as I can tell, there isn't a reason to keep it in watch where it gets fired constantly. If anyone has any other reason it shouldn't be moved, we can close the PR.

@Wade-McDaniel or @ghenry22, if you guys could weigh-in on this, that'd be super.