### PR TITLE
Fix interval skip

### DIFF
--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -261,15 +261,28 @@ MusicControlsInfo * musicControlsSettings;
             commandCenter.skipForwardCommand.preferredIntervals = @[@(musicControlsSettings.skipForwardInterval)];
             [commandCenter.skipForwardCommand setEnabled:true];
             [commandCenter.skipForwardCommand addTarget: self action:@selector(skipForwardEvent:)];
+        } else {
+            if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_0) {
+                [commandCenter.skipForwardCommand removeTarget:self];
+            }
         }
         if(musicControlsSettings.hasSkipBackward){
             commandCenter.skipBackwardCommand.preferredIntervals = @[@(musicControlsSettings.skipBackwardInterval)];
             [commandCenter.skipBackwardCommand setEnabled:true];
             [commandCenter.skipBackwardCommand addTarget: self action:@selector(skipBackwardEvent:)];
+        } else {
+            if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_0) {
+                [commandCenter.skipBackwardCommand removeTarget:self];
+            }
         }
         if(musicControlsSettings.hasScrubbing){
             [commandCenter.changePlaybackPositionCommand setEnabled:true];
             [commandCenter.changePlaybackPositionCommand addTarget:self action:@selector(changedThumbSliderOnLockScreen:)];
+        } else {
+            if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_0) {
+                [commandCenter.changePlaybackPositionCommand setEnabled:false];
+                [commandCenter.changePlaybackPositionCommand removeTarget:self action:NULL];
+            }
         }
     }
 }

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -263,7 +263,7 @@ MusicControlsInfo * musicControlsSettings;
             [commandCenter.skipForwardCommand addTarget: self action:@selector(skipForwardEvent:)];
         }
         if(musicControlsSettings.hasSkipBackward){
-            commandCenter.skipBackwardCommand.preferredIntervals = @[@(musicControlsSettings.skipForwardInterval)];
+            commandCenter.skipBackwardCommand.preferredIntervals = @[@(musicControlsSettings.skipBackwardInterval)];
             [commandCenter.skipBackwardCommand setEnabled:true];
             [commandCenter.skipBackwardCommand addTarget: self action:@selector(skipBackwardEvent:)];
         }


### PR DESCRIPTION
This fixes a couple of things with the skipInterval options:

1) skipForward interval value was used for the skipBackward control

2) once hasForwardInterval or hasBackwardInterval are enabled once they cannot be disabled and returned to hasSkip options as the native listeners are not unregistered on change of plugin configuration.