### PR TITLE
MediaSessionCompat error on API 20 or earlier

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,6 +33,11 @@
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
 			<service android:name="com.homerours.musiccontrols.MusicControlsNotificationKiller"></service>
+			<receiver android:name="android.support.v4.media.session.MediaButtonReceiver">
+				<intent-filter>
+					<action android:name="android.intent.action.MEDIA_BUTTON" />
+				</intent-filter>
+			</receiver>
 		</config-file>
 
 		<source-file src="src/android/MusicControls.java" target-dir="src/com/homerours/musiccontrols" />


### PR DESCRIPTION
On devices using android with API 20 or earlier (like android 4.4) is throwing an error:
```
java.lang.IllegalArgumentException: MediaButtonReceiver component may not be null.
   at android.support.v4.media.session.MediaSessionCompat$MediaSessionImplBase.<init>(MediaSessionCompat.java:1223)
   at android.support.v4.media.session.MediaSessionCompat.<init>(MediaSessionCompat.java:215)
   at com.homerours.musiccontrols.MusicControls.initialize(MusicControls.java:103)
   ...
```
[Error line](https://github.com/homerours/cordova-music-controls-plugin/blob/master/src/android/MusicControls.java#L103)

Checking on [android docs](https://developer.android.com/reference/android/support/v4/media/session/MediaSessionCompat.html#MediaSessionCompat(android.content.Context,%20java.lang.String)) you can see this note:
**`For API 20 or earlier, note that a media button receiver is required for handling Intent.ACTION_MEDIA_BUTTON.`**

There is a simple solution that can be found directly on [android docs](https://developer.android.com/reference/android/support/v4-media-session/MediaButtonReceiver), just definig the receiver on AndroidManifest.xml
```
 <receiver android:name="android.support.v4.media.session.MediaButtonReceiver" >
   <intent-filter>
     <action android:name="android.intent.action.MEDIA_BUTTON" />
   </intent-filter>
 </receiver>
```
Tested on a Zenfone with android 4.4 and a Xiaomi with android 9
