### PR TITLE
Return MPRemoteCommandHandlerStatus required for iOS 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "cordova-plugin-music-controls",
-  "version": "2.2.0",
+  "name": "cordova-music-controls",
+  "version": "2.2.1",
   "description": "Music controls for Cordova apps",
   "cordova": {
-    "id": "cordova-plugin-music-controls",
+    "id": "cordova-music-controls",
     "platforms": ["android", "windows", "ios"]
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/homerours/cordova-music-controls-plugin.git"
+    "url": "git+https://github.com/yoojene/cordova-music-controls.git"
   },
   "keywords": [
     "cordova",
@@ -31,8 +31,8 @@
   "author": "homerours",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/homerours/cordova-music-controls-plugin/issues"
+    "url": "https://github.com/yoojene/cordova-music-controls/issues"
   },
   "homepage":
-    "https://github.com/homerours/cordova-music-controls-plugin#readme"
+    "https://github.com/yoojene/cordova-music-controls#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
-	id="cordova-plugin-music-controls"
-	version="2.2.0">
+	id="cordova-music-controls"
+	version="2.2.1">
 	<name>MusicControls</name>
 	<keywords>cordova,music,controller,controls,media,plugin,notification,lockscreen,now,playing</keywords>
-	<repo>https://github.com/homerours/cordova-music-controls-plugin</repo>
+	<repo>https://github.com/yoojene/cordova-music-controls</repo>
 	<description>Music controls for Cordova apps</description>
 	<license>MIT</license>
 	<author>HomerOurs</author>

--- a/src/ios/MusicControls.h
+++ b/src/ios/MusicControls.h
@@ -22,11 +22,11 @@
 - (void) updateElapsed: (CDVInvokedUrlCommand *) command;
 - (void) destroy: (CDVInvokedUrlCommand *) command;
 - (void) watch: (CDVInvokedUrlCommand *) command;
-- (void) remoteEvent:(MPRemoteCommandEvent *) event;
-- (void) playEvent:(MPRemoteCommandEvent *) event;
-- (void) pauseEvent:(MPRemoteCommandEvent *) event;
-- (void) nextTrackEvent:(MPRemoteCommandEvent *) event;
-- (void) prevTrackEvent:(MPRemoteCommandEvent *) event;
+- (MPRemoteCommandHandlerStatus) remoteEvent:(MPRemoteCommandEvent *) event;
+- (MPRemoteCommandHandlerStatus) playEvent:(MPRemoteCommandEvent *) event;
+- (MPRemoteCommandHandlerStatus) pauseEvent:(MPRemoteCommandEvent *) event;
+- (MPRemoteCommandHandlerStatus) nextTrackEvent:(MPRemoteCommandEvent *) event;
+- (MPRemoteCommandHandlerStatus) prevTrackEvent:(MPRemoteCommandEvent *) event;
 - (void) skipForwardEvent: (MPSkipIntervalCommandEvent *) event;
 - (void) skipBackwardEvent: (MPSkipIntervalCommandEvent *) event;
 - (MPMediaItemArtwork *) createCoverArtwork: (NSString *) coverUri;

--- a/src/ios/MusicControls.h
+++ b/src/ios/MusicControls.h
@@ -3,6 +3,7 @@
 // Music Controls Cordova Plugin
 //
 // Created by Juan Gonzalez on 12/16/16.
+// Updated by Eugene Cross on 14/12/19 for iOS 13 compatibility
 //
 
 #ifndef MusicControls_h

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -151,36 +151,43 @@ MusicControlsInfo * musicControlsSettings;
 //So if we want to use the new scrubbing support in the lock screen we must implement dummy handlers
 //for those functions that we already deal with through notifications (play, pause, skip etc)
 //otherwise those remote control actions will be disabled
-- (void) remoteEvent:(MPRemoteCommandEvent *)event {
-    return;
+- (MPRemoteCommandHandlerStatus) remoteEvent:(MPRemoteCommandEvent *)event {
+    return MPRemoteCommandHandlerStatusSuccess;
 }
 
-- (void) nextTrackEvent:(MPRemoteCommandEvent *)event {
+- (MPRemoteCommandHandlerStatus) nextTrackEvent:(MPRemoteCommandEvent *)event {
     NSString * action = @"music-controls-next";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
+    return MPRemoteCommandHandlerStatusSuccess;
 }
 
-- (void) prevTrackEvent:(MPRemoteCommandEvent *)event {
+- (MPRemoteCommandHandlerStatus) prevTrackEvent:(MPRemoteCommandEvent *)event {
     NSString * action = @"music-controls-previous";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
+    return MPRemoteCommandHandlerStatusSuccess;
+
 }
 
-- (void) pauseEvent:(MPRemoteCommandEvent *)event {
+- (MPRemoteCommandHandlerStatus) pauseEvent:(MPRemoteCommandEvent *)event {
     NSString * action = @"music-controls-pause";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
+    return MPRemoteCommandHandlerStatusSuccess;
+
 }
 
-- (void) playEvent:(MPRemoteCommandEvent *)event {
+- (MPRemoteCommandHandlerStatus) playEvent:(MPRemoteCommandEvent *)event {
     NSString * action = @"music-controls-play";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
+    return MPRemoteCommandHandlerStatusSuccess;
+
 }
 
 //Handle all other remote control events

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -4,6 +4,7 @@
 //
 //  Created by Juan Gonzalez on 12/16/16.
 //  Updated by Gaven Henry on 11/7/17 for iOS 11 compatibility & new features
+//  Updated by Eugene Cross on 14/12/19 for iOS 13 compatibility
 //
 //
 

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -132,19 +132,21 @@ MusicControlsInfo * musicControlsSettings;
 }
 
 //Handle the skip forward event
-- (void) skipForwardEvent:(MPSkipIntervalCommandEvent *)event {
+- (MPRemoteCommandHandlerStatus) skipForwardEvent:(MPSkipIntervalCommandEvent *)event {
     NSString * action = @"music-controls-skip-forward";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
+    return MPRemoteCommandHandlerStatusSuccess;
 }
 
 //Handle the skip backward event
-- (void) skipBackwardEvent:(MPSkipIntervalCommandEvent *)event {
+- (MPRemoteCommandHandlerStatus) skipBackwardEvent:(MPSkipIntervalCommandEvent *)event {
     NSString * action = @"music-controls-skip-backward";
     NSString * jsonAction = [NSString stringWithFormat:@"{\"message\":\"%@\"}", action];
     CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonAction];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:[self latestEventCallbackId]];
+    return MPRemoteCommandHandlerStatusSuccess;
 }
 
 //If MPRemoteCommandCenter is enabled for any function we must enable it for all and register a handler

--- a/src/ios/MusicControls.m
+++ b/src/ios/MusicControls.m
@@ -4,7 +4,7 @@
 //
 //  Created by Juan Gonzalez on 12/16/16.
 //  Updated by Gaven Henry on 11/7/17 for iOS 11 compatibility & new features
-//  Updated by Eugene Cross on 14/12/19 for iOS 13 compatibility
+//  Updated by Eugene Cross on 14/10/19 for iOS 13 compatibility
 //
 //
 


### PR DESCRIPTION
**PR summary**

Apple API docs state that functions with `MPRemoteCommandEvent` params should return `MPRemoteCommandHandlerStatus `.  

Current implementation has these as returning `void`, which is crashing apps using this plugin in iOS 13.

PR returns `MPRemoteCommandHandlerStatusSuccess` in all actions of this type

**Issue(s) related**

https://github.com/homerours/cordova-music-controls-plugin/issues/157

**Steps to test**

1. Call `MusicControls.create({..` on iOS 13 results in app crash
2. Update code with this PR
3. Call `MusicControls.create({..` on iOS 13 results in app not crashing